### PR TITLE
RDKEMW-6475: Move FirmwareUpdate related SystemServices APIs to FirmwareUpdate Plugin

### DIFF
--- a/FirmwareUpdate/FirmwareUpdateImplementation.cpp
+++ b/FirmwareUpdate/FirmwareUpdateImplementation.cpp
@@ -19,6 +19,9 @@
 
 #include "FirmwareUpdateImplementation.h"
 
+#define TR181_FW_DELAY_REBOOT "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AutoReboot.fwDelayReboot"
+#define MAX_REBOOT_DELAY 86400 /* 24Hr = 86400 sec */
+
 std::atomic<bool> isFlashingInProgress(false);
 std::mutex flashMutex;
 std::mutex logMutex;
@@ -835,6 +838,39 @@ namespace WPEFramework {
             return status;
         }
 
+        Core::hresult FirmwareUpdateImplementation::SetFirmwareRebootDelay (const uint32_t delaySeconds, bool& success)
+        {
+             bool result = false;
+             Core::hresult status = Core::ERROR_GENERAL;
+
+             /* we can delay with max 24 Hrs = 86400 sec */
+             if (delaySeconds > 0 && delaySeconds <= MAX_REBOOT_DELAY ){
+
+                  std::string delay_in_sec = std::to_string(delaySeconds);
+                  const char * set_rfc_val = delay_in_sec.c_str();
+
+                  LOGINFO("set_rfc_value %s\n",set_rfc_val);
+
+                  /*set tr181Set command from here*/
+                  WDMP_STATUS rfcStatus = setRFCParameter((char*)"thunderapi",
+                  TR181_FW_DELAY_REBOOT, set_rfc_val, WDMP_INT);
+
+                  if ( WDMP_SUCCESS == rfcStatus){
+                      result=true;
+                      status = Core::ERROR_NONE;
+                      LOGINFO("Success Setting setFirmwareRebootDelay value\n");
+                  }
+                  else {
+                      LOGINFO("Failed Setting setFirmwareRebootDelay value %s\n",getRFCErrorString(rfcStatus));
+                  }
+             }
+             else {
+                 /* we didnt get a valid Auto Reboot delay */
+                 LOGERR("Invalid setFirmwareRebootDelay Value Max.Value is 86400 sec\n");
+             }
+             success = result;
+             return status;
+        }
 
     } // namespace Plugin
 } // namespace WPEFramework

--- a/FirmwareUpdate/FirmwareUpdateImplementation.h
+++ b/FirmwareUpdate/FirmwareUpdateImplementation.h
@@ -105,6 +105,7 @@ namespace Plugin {
         Core::hresult Unregister(Exchange::IFirmwareUpdate::INotification *notification ) ;
         Core::hresult UpdateFirmware(const string& firmwareFilepath , const string& firmwareType , Result &result ) override ;
         Core::hresult GetUpdateState(GetUpdateStateResult& getUpdateStateResult )  override;
+        Core::hresult SetFirmwareRebootDelay (const uint32_t delaySeconds, bool& success) override;
         void startProgressTimer() ;
         int flashImage(const char *server_url, const char *upgrade_file, const char *reboot_flag, const char *proto, int upgrade_type, const char *maint ,const char *initiated_type ,const char * codebig) ;
         void flashImageThread(std::string firmwareFilepath,std::string firmwareType) ;


### PR DESCRIPTION
Reason for change: Moved and added COM-RPC support for SetFirmwareRebootDelay API. 
Test Procedure: Test the SetFirmwareRebootDelay API 
Risks: Low
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com