### PR TITLE
STBT-51349 Premerge CI integrate middleware development layer to IA

### DIFF
--- a/FirmwareUpdate/FirmwareUpdateImplementation.cpp
+++ b/FirmwareUpdate/FirmwareUpdateImplementation.cpp
@@ -807,6 +807,8 @@ namespace WPEFramework {
 
         Core::hresult FirmwareUpdateImplementation::GetUpdateState(GetUpdateStateResult& getUpdateStateResult ) 
         {
+			LOGINFO("Hello Tester! This is for Premerge CI STBT-51349_Dev_IA_V3 testing");
+			
             Core::hresult status = Core::ERROR_GENERAL;    
             std::string strState = "";
             std::string strSubState = "";


### PR DESCRIPTION
Reason for change: integrate the middleware development layer into the IA
Test Procedure: None
Risks: Low
Signed-off-by: ramkumar_prabaharan@comcast.com