### PR TITLE
RDKEMW-15276: Add try/catch guards for std::thread() calls in MaintenanceManager

### DIFF
--- a/MaintenanceManager/CMakeLists.txt
+++ b/MaintenanceManager/CMakeLists.txt
@@ -80,6 +80,11 @@ else()
     target_compile_definitions(${MODULE_NAME} PRIVATE TASK_TIMEOUT=3600) # default value
 endif()
 
+# Enable test thread exception injection (for verifying catch-block recovery paths)
+if (ENABLE_TEST_THREAD_EXCEPTION)
+    target_compile_definitions(${MODULE_NAME} PRIVATE ENABLE_TEST_THREAD_EXCEPTION=ON)
+endif()
+
 # Include and link for signal, csignal, time, ctime headers
 target_link_libraries(${MODULE_NAME} PRIVATE pthread rt)
 

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1578,9 +1578,13 @@ namespace WPEFramework
             {
                 m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
             }
-            catch (const std::system_error &e)
+            catch (const std::exception &e)
             {
-                MM_LOGERR("Failed to create task execution thread on bootup: %s (code %d)", e.what(), e.code().value());
+                MM_LOGERR("Failed to create task execution thread in Bootup: [%s] %s", typeid(e).name(), e.what());
+                g_unsolicited_complete = true;
+                m_statusMutex.lock();
+                MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
+                m_statusMutex.unlock();
             }
 #endif
         }
@@ -2459,9 +2463,9 @@ namespace WPEFramework
                     m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
                     result = true;
                 }
-                catch (const std::system_error &e)
+                catch (const std::exception &e)
                 {
-                    MM_LOGERR("Failed to create task execution thread in startMaintenance: %s (code %d)", e.what(), e.code().value());
+                    MM_LOGERR("Failed to create task execution thread in startMaintenance: [%s] %s", typeid(e).name(), e.what());
                     result = false;
                 }
             }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -2450,6 +2450,8 @@ namespace WPEFramework
                 /* we set this to false */
                 g_is_critical_maintenance = "false";
 
+                m_statusMutex.unlock();
+
                 /* if there is any active thread, join it before executing the tasks from startMaintenance
                  * especially when device is in offline mode*/
                 if (m_thread.joinable())
@@ -2472,8 +2474,8 @@ namespace WPEFramework
             else
             {
                 MM_LOGINFO("Already a maintenance is in Progress. Please wait for it to complete !!");
+                m_statusMutex.unlock();
             }
-            m_statusMutex.unlock();
 #if defined(ENABLE_JOURNAL_LOGGING)
             MM_RETURN_RESPONSE(result);
 #endif

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -2475,11 +2475,8 @@ namespace WPEFramework
                 catch (const std::exception &e)
                 {
                     MM_LOGERR("Failed to create task execution thread in startMaintenance: [%s] %s", typeid(e).name(), e.what());
-                    {
-                        std::lock_guard<std::mutex> lock(m_statusMutex);
-                        g_is_critical_maintenance = std::move(prev_critical_maintenance);
-                        onMaintenanceStatusChange(MAINTENANCE_ERROR);
-                    }
+                    g_is_critical_maintenance = std::move(prev_critical_maintenance);
+                    onMaintenanceStatusChange(MAINTENANCE_ERROR);
                     result = false;
                 }
             }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1574,7 +1574,14 @@ namespace WPEFramework
             m_statusMutex.unlock();
 
 #if !defined(GTEST_ENABLE)
-            m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+            try
+            {
+                m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+            }
+            catch (const std::system_error &e)
+            {
+                MM_LOGERR("Failed to create task execution thread on bootup: %s (code %d)", e.what(), e.code().value());
+            }
 #endif
         }
 
@@ -2447,9 +2454,16 @@ namespace WPEFramework
                     MM_LOGINFO("Thread joined successfully");
                 }
 
-                m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
-
-                result = true;
+                try
+                {
+                    m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
+                    result = true;
+                }
+                catch (const std::system_error &e)
+                {
+                    MM_LOGERR("Failed to create task execution thread in startMaintenance: %s (code %d)", e.what(), e.code().value());
+                    result = false;
+                }
             }
             else
             {

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -2476,7 +2476,6 @@ namespace WPEFramework
                 {
                     MM_LOGERR("Failed to create task execution thread in startMaintenance: [%s] %s", typeid(e).name(), e.what());
                     g_is_critical_maintenance = std::move(prev_critical_maintenance);
-                    onMaintenanceStatusChange(MAINTENANCE_ERROR);
                     result = false;
                 }
             }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1576,6 +1576,9 @@ namespace WPEFramework
 #if !defined(GTEST_ENABLE)
             try
             {
+#ifdef ENABLE_TEST_THREAD_EXCEPTION
+                MM_TEST_THROW_THREAD_EXCEPTION();
+#endif
                 m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
             }
             catch (const std::exception &e)
@@ -2462,6 +2465,9 @@ namespace WPEFramework
 
                 try
                 {
+#ifdef ENABLE_TEST_THREAD_EXCEPTION
+                    MM_TEST_THROW_THREAD_EXCEPTION();
+#endif
                     m_thread = std::thread(&MaintenanceManager::task_execution_thread, _instance);
                     result = true;
                 }

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -1584,10 +1584,11 @@ namespace WPEFramework
             catch (const std::exception &e)
             {
                 MM_LOGERR("Failed to create task execution thread in Bootup: [%s] %s", typeid(e).name(), e.what());
-                g_unsolicited_complete = true;
-                m_statusMutex.lock();
-                MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
-                m_statusMutex.unlock();
+                {
+                    std::lock_guard<std::mutex> lock(m_statusMutex);
+                    g_unsolicited_complete = true;
+                    MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
+                }
             }
 #endif
         }
@@ -2450,10 +2451,10 @@ namespace WPEFramework
                  * irrespective of XConf configuration */
                 g_is_reboot_pending = "true";
 
+                /* Save previous value before overwriting, for rollback on thread creation failure */
+                string prev_critical_maintenance = g_is_critical_maintenance;
                 /* we set this to false */
                 g_is_critical_maintenance = "false";
-
-                m_statusMutex.unlock();
 
                 /* if there is any active thread, join it before executing the tasks from startMaintenance
                  * especially when device is in offline mode*/
@@ -2474,14 +2475,19 @@ namespace WPEFramework
                 catch (const std::exception &e)
                 {
                     MM_LOGERR("Failed to create task execution thread in startMaintenance: [%s] %s", typeid(e).name(), e.what());
+                    {
+                        std::lock_guard<std::mutex> lock(m_statusMutex);
+                        g_is_critical_maintenance = std::move(prev_critical_maintenance);
+                        onMaintenanceStatusChange(MAINTENANCE_ERROR);
+                    }
                     result = false;
                 }
             }
             else
             {
                 MM_LOGINFO("Already a maintenance is in Progress. Please wait for it to complete !!");
-                m_statusMutex.unlock();
             }
+            m_statusMutex.unlock();
 #if defined(ENABLE_JOURNAL_LOGGING)
             MM_RETURN_RESPONSE(result);
 #endif

--- a/MaintenanceManager/MaintenanceManager.h
+++ b/MaintenanceManager/MaintenanceManager.h
@@ -80,6 +80,12 @@
 #define MM_LOGERR(format, ...)  LOGERR(format, ##__VA_ARGS__)
 #endif /* end of ENABLE_JOURNAL_LOGGING */
 
+#ifdef ENABLE_TEST_THREAD_EXCEPTION
+#include <system_error>
+#define MM_TEST_THROW_THREAD_EXCEPTION() \
+    throw std::system_error(std::make_error_code(std::errc::resource_unavailable_try_again), "[TEST] Simulated thread creation failure")
+#endif
+
 /* MaintenanceManager Services Triggered Events. */
 #define EVT_ONMAINTMGRSAMPLEEVENT "onSampleEvent"
 #define EVT_ONMAINTENANCSTATUSCHANGE "onMaintenanceStatusChange" /* Maintenance Status change */

--- a/Tests/L1Tests/tests/test_MaintenanceManager.cpp
+++ b/Tests/L1Tests/tests/test_MaintenanceManager.cpp
@@ -1637,9 +1637,9 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ReturnsFailure)
     EXPECT_EQ(response_, "{\"success\":false}");
 }
 
-/* 2. onMaintenanceStatusChange(MAINTENANCE_ERROR) is called in the catch
- *    block, so m_notify_status must be MAINTENANCE_ERROR afterwards. */
-TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_SetsMaintenanceError)
+/* 2. The catch block does NOT call onMaintenanceStatusChange(), so
+ *    m_notify_status must remain MAINTENANCE_IDLE after thread creation fails. */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_StatusRemainsIdle)
 {
     SetupForStartMaintenance(plugin_);
 
@@ -1648,16 +1648,14 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_SetsMaintenanceE
                     _T("{}"),
                     response_);
 
-    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_ERROR);
+    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_IDLE);
 }
 
-/* 3. getMaintenanceActivityStatus must reflect the MAINTENANCE_ERROR status
- *    and isRebootPending:false (g_is_reboot_pending was set to "true" before
- *    the throw, but the catch does NOT roll it back in this version – the
- *    status field should show ERROR and the reboot-pending flag the actual
- *    stored string value).
+/* 3. getMaintenanceActivityStatus must reflect MAINTENANCE_IDLE after a
+ *    thread-creation failure, because the catch block no longer calls
+ *    onMaintenanceStatusChange(MAINTENANCE_ERROR).
  *    This test documents the observable API surface after the catch runs. */
-TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ActivityStatusShowsError)
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ActivityStatusShowsIdle)
 {
     SetupForStartMaintenance(plugin_);
     plugin_->g_is_reboot_pending = "false"; // start with known value
@@ -1672,10 +1670,8 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ActivityStatusSh
                               _T("org.rdk.MaintenanceManager.1.getMaintenanceActivityStatus"),
                               _T("{}"),
                               response_));
-    /* maintenanceStatus must be ERROR; isRebootPending reflects whatever
-     * g_is_reboot_pending holds (set to "true" inside startMaintenance
-     * before the throw, so the response shows true). */
-    EXPECT_NE(response_.find("\"maintenanceStatus\":\"MAINTENANCE_ERROR\""), string::npos);
+    /* maintenanceStatus must be IDLE */
+    EXPECT_NE(response_.find("\"maintenanceStatus\":\"MAINTENANCE_IDLE\""), string::npos);
 }
 
 /* 4. g_is_critical_maintenance must be restored to its value from before
@@ -1710,7 +1706,7 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_RestoresCritical
     EXPECT_EQ(plugin_->g_is_critical_maintenance, "false");
 }
 
-/* 6. After the catch, m_notify_status is MAINTENANCE_ERROR (not
+/* 6. After the catch, m_notify_status is still MAINTENANCE_IDLE (not
  *    MAINTENANCE_STARTED), so the startMaintenance guard passes on a
  *    second call – i.e. the plugin can be retried without getting stuck. */
 TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_AllowsImmediateRetry)
@@ -1725,7 +1721,7 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_AllowsImmediateR
     EXPECT_EQ(response_, "{\"success\":false}");
 
     /* guard: MAINTENANCE_STARTED != m_notify_status && g_unsolicited_complete.
-     * m_notify_status is now MAINTENANCE_ERROR, g_unsolicited_complete is still
+     * m_notify_status is still MAINTENANCE_IDLE, g_unsolicited_complete is still
      * true, so the guard should pass and the catch should fire again. */
     handler_.Invoke(connection,
                     _T("org.rdk.MaintenanceManager.1.startMaintenance"),
@@ -1733,8 +1729,8 @@ TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_AllowsImmediateR
                     response_);
     EXPECT_EQ(response_, "{\"success\":false}");
 
-    /* State should still reflect a clean catch-block outcome */
-    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_ERROR);
+    /* Status remains IDLE since the catch no longer calls onMaintenanceStatusChange */
+    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_IDLE);
 }
 
 #endif /* ENABLE_TEST_THREAD_EXCEPTION */

--- a/Tests/L1Tests/tests/test_MaintenanceManager.cpp
+++ b/Tests/L1Tests/tests/test_MaintenanceManager.cpp
@@ -1603,5 +1603,140 @@ TEST_F(MaintenanceManagerTest, InitializeIARM_RegistersEventAndBootsUp) {
     plugin_->m_service = &service_;    
     plugin_->InitializeIARM();
 }
-#endif
+
+/* -----------------------------------------------------------------------
+ * L1 tests for the startMaintenance() catch block
+ *
+ * Compiled only when ENABLE_TEST_THREAD_EXCEPTION is defined (alongside
+ * GTEST_ENABLE).  That flag makes MM_TEST_THROW_THREAD_EXCEPTION() throw
+ * a std::system_error inside the try block so the catch path is exercised
+ * without touching the real thread-creation call.
+ * ----------------------------------------------------------------------- */
+#ifdef ENABLE_TEST_THREAD_EXCEPTION
+
+/* Helper: put the plugin into the state that allows startMaintenance to
+ * proceed past the guard (MAINTENANCE_STARTED != m_notify_status &&
+ * g_unsolicited_complete). */
+static void SetupForStartMaintenance(Core::ProxyType<Plugin::MaintenanceManager>& plugin)
+{
+    Plugin::MaintenanceManager::_instance = &(*plugin);
+    plugin->g_unsolicited_complete = true;
+    plugin->setNotifyStatus(MAINTENANCE_IDLE);
+}
+
+/* 1. The JSON-RPC response reports failure when thread creation throws. */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ReturnsFailure)
+{
+    SetupForStartMaintenance(plugin_);
+
+    EXPECT_EQ(Core::ERROR_NONE,
+              handler_.Invoke(connection,
+                              _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                              _T("{}"),
+                              response_));
+    EXPECT_EQ(response_, "{\"success\":false}");
+}
+
+/* 2. onMaintenanceStatusChange(MAINTENANCE_ERROR) is called in the catch
+ *    block, so m_notify_status must be MAINTENANCE_ERROR afterwards. */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_SetsMaintenanceError)
+{
+    SetupForStartMaintenance(plugin_);
+
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+
+    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_ERROR);
+}
+
+/* 3. getMaintenanceActivityStatus must reflect the MAINTENANCE_ERROR status
+ *    and isRebootPending:false (g_is_reboot_pending was set to "true" before
+ *    the throw, but the catch does NOT roll it back in this version – the
+ *    status field should show ERROR and the reboot-pending flag the actual
+ *    stored string value).
+ *    This test documents the observable API surface after the catch runs. */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_ActivityStatusShowsError)
+{
+    SetupForStartMaintenance(plugin_);
+    plugin_->g_is_reboot_pending = "false"; // start with known value
+
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+
+    EXPECT_EQ(Core::ERROR_NONE,
+              handler_.Invoke(connection,
+                              _T("org.rdk.MaintenanceManager.1.getMaintenanceActivityStatus"),
+                              _T("{}"),
+                              response_));
+    /* maintenanceStatus must be ERROR; isRebootPending reflects whatever
+     * g_is_reboot_pending holds (set to "true" inside startMaintenance
+     * before the throw, so the response shows true). */
+    EXPECT_NE(response_.find("\"maintenanceStatus\":\"MAINTENANCE_ERROR\""), string::npos);
+}
+
+/* 4. g_is_critical_maintenance must be restored to its value from before
+ *    startMaintenance was called (the catch does:
+ *    g_is_critical_maintenance = std::move(prev_critical_maintenance)). */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_RestoresCriticalMaintenance)
+{
+    SetupForStartMaintenance(plugin_);
+    const std::string prev = "true";
+    plugin_->g_is_critical_maintenance = prev;
+
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+
+    EXPECT_EQ(plugin_->g_is_critical_maintenance, prev);
+}
+
+/* 5. g_is_critical_maintenance should also be restored when the previous
+ *    value was "false" (the common case). */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_RestoresCriticalMaintenance_WasFalse)
+{
+    SetupForStartMaintenance(plugin_);
+    plugin_->g_is_critical_maintenance = "false";
+
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+
+    EXPECT_EQ(plugin_->g_is_critical_maintenance, "false");
+}
+
+/* 6. After the catch, m_notify_status is MAINTENANCE_ERROR (not
+ *    MAINTENANCE_STARTED), so the startMaintenance guard passes on a
+ *    second call – i.e. the plugin can be retried without getting stuck. */
+TEST_F(MaintenanceManagerTest, startMaintenance_ThreadException_AllowsImmediateRetry)
+{
+    SetupForStartMaintenance(plugin_);
+
+    /* first attempt – catch fires */
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+    EXPECT_EQ(response_, "{\"success\":false}");
+
+    /* guard: MAINTENANCE_STARTED != m_notify_status && g_unsolicited_complete.
+     * m_notify_status is now MAINTENANCE_ERROR, g_unsolicited_complete is still
+     * true, so the guard should pass and the catch should fire again. */
+    handler_.Invoke(connection,
+                    _T("org.rdk.MaintenanceManager.1.startMaintenance"),
+                    _T("{}"),
+                    response_);
+    EXPECT_EQ(response_, "{\"success\":false}");
+
+    /* State should still reflect a clean catch-block outcome */
+    EXPECT_EQ(plugin_->getNotifyStatus(), MAINTENANCE_ERROR);
+}
+
+#endif /* ENABLE_TEST_THREAD_EXCEPTION */
+#endif /* GTEST_ENABLE */
 


### PR DESCRIPTION
Reason for change: Add try/catch guards for thread creation in MM
Test Procedure : Build & Verify
Version : Minor
Risks: Low