### PR TITLE
Feature/rdk 55825 : add telemetry markers t2

### DIFF
--- a/MaintenanceManager/CMakeLists.txt
+++ b/MaintenanceManager/CMakeLists.txt
@@ -88,6 +88,12 @@ endif()
 # Include and link for signal, csignal, time, ctime headers
 target_link_libraries(${MODULE_NAME} PRIVATE pthread rt)
 
+find_package(Telemetry)
+if (TELEMETRY_FOUND)
+    target_link_libraries(${MODULE_NAME} PRIVATE ${TELEMETRY_LIBRARIES})
+    target_include_directories(${MODULE_NAME} PRIVATE ${TELEMETRY_INCLUDE_DIRS})
+endif()
+
 install(TARGETS ${MODULE_NAME}
         DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
 

--- a/MaintenanceManager/MaintenanceManager.cpp
+++ b/MaintenanceManager/MaintenanceManager.cpp
@@ -48,6 +48,8 @@
 #include "UtilsfileExists.h"
 #include "UtilsgetFileContent.h"
 
+#include <telemetry_busmessage_sender.h>
+
 #if defined(USE_IARMBUS) || defined(USE_IARM_BUS)
 #include "libIARM.h"
 #endif
@@ -449,6 +451,9 @@ namespace WPEFramework
                 MaintenanceManager::_instance->onMaintenanceStatusChange(MAINTENANCE_ERROR);
                 m_statusMutex.unlock();
                 MM_LOGINFO("Maintenance is exiting as device is not connected to internet.");
+
+				t2_event_d("SYST_ERR_MaintNetworkFail", 1);
+				
                 if (UNSOLICITED_MAINTENANCE == g_maintenance_type && !g_unsolicited_complete)
                 {
                     g_unsolicited_complete = true;
@@ -466,7 +471,12 @@ namespace WPEFramework
 
             MM_LOGINFO("Reboot_Pending :%s", g_is_reboot_pending.c_str());
             MM_LOGINFO("%s", UNSOLICITED_MAINTENANCE == g_maintenance_type ? "---------------UNSOLICITED_MAINTENANCE--------------" : "=============SOLICITED_MAINTENANCE===============");
-            
+
+			if (UNSOLICITED_MAINTENANCE != g_maintenance_type) 
+			{
+				t2_event_d("SYST_INFO_SOMT", 1);
+			}
+			
             if (!g_whoami_support_enabled && g_suppress_maintenance_enabled && skipFirmwareCheck)
             {
                 /* set the task status of Firmware Download */
@@ -633,6 +643,10 @@ namespace WPEFramework
                         {
                             MM_LOGERR("getDeviceInitializationContext failed");
                         }
+						if (joGetResult.HasLabel("success") && !joGetResult["success"].Boolean())
+						{
+							t2_event_d("SYST_ERROR_WAI_InitERR", 1);
+						}
                     }
                     else
                     {
@@ -1632,6 +1646,12 @@ namespace WPEFramework
                         MM_LOGINFO("MaintMGR Status %d", module_status);
                         string status_string = moduleStatusToString(module_status);
                         MM_LOGINFO("MaintMGR Status %s", status_string.c_str());
+
+						if (status_string == "MAINTENANCE_RFC_ERROR") 
+						{
+							t2_event_d("SYST_ERR_RFC", 1);
+						}
+						
                         switch (module_status)
                         {
                             case MAINT_RFC_COMPLETE:
@@ -1903,6 +1923,12 @@ namespace WPEFramework
             }
 
             response["maintenanceStatus"] = notifyStatusToString(m_notify_status);
+
+			if (notifyStatusToString(m_notify_status) == "MAINTENANCE_INCOMPLETE")
+			{
+				t2_event_d("SYST_INFO_MaintnceIncmpl", 1);
+			}
+			
             if (strcmp("NA", LastSuccessfulCompletionTime.c_str()) == 0)
             {
                 response["LastSuccessfulCompletionTime"] = 0; // stoi is not able handle "NA"
@@ -2713,6 +2739,12 @@ namespace WPEFramework
             /* we store the updated value as well */
             m_notify_status = status;
             params["maintenanceStatus"] = notifyStatusToString(status);
+
+			if (notifyStatusToString(m_notify_status) == "MAINTENANCE_INCOMPLETE")
+			{
+				t2_event_d("SYST_INFO_MaintnceIncmpl", 1);
+			}
+			
             sendNotify(EVT_ONMAINTENANCSTATUSCHANGE, params);
 #if defined(ENABLE_JOURNAL_LOGGING)
             MM_SEND_NOTIFY(EVT_ONMAINTENANCSTATUSCHANGE, params);

--- a/MaintenanceManager/cmake/FindTelemetry.cmake
+++ b/MaintenanceManager/cmake/FindTelemetry.cmake
@@ -1,0 +1,35 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find Telemetry library
+# Once done this will define
+#  TELEMETRY_FOUND - System has Telemetry
+#  TELEMETRY_LIBRARIES - The libraries needed to use Telemetry
+#  TELEMETRY_INCLUDE_DIRS - The headers needed to use Telemetry
+
+find_package(PkgConfig)
+
+find_library(TELEMETRY_LIBRARIES NAMES telemetry_msgsender)
+find_path(TELEMETRY_INCLUDE_DIRS NAMES telemetry_busmessage_sender.h)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(TELEMETRY DEFAULT_MSG TELEMETRY_INCLUDE_DIRS TELEMETRY_LIBRARIES)
+
+mark_as_advanced(
+    TELEMETRY_FOUND
+    TELEMETRY_INCLUDE_DIRS
+    TELEMETRY_LIBRARIES)


### PR DESCRIPTION
RDK-55825: Adding t2 events for MaintenanceManager plugin
Reason for change:

- Adding t2 for "getDeviceInitializationContext: response: {"success":false" search string
- Adding t2 for "Maintenance is exiting as device is not connected to internet" search string
- Adding t2 for "MAINTENANCE_RFC_ERROR" search string
- Adding t2 for ""maintenanceStatus":"MAINTENANCE_INCOMPLETE"" search string
- Adding t2 for "task_execution_thread: =============SOLICITED_MAINTENANCE" search string

Test Procedure: see Jira ticket
Risks: Low
Priority: Medium